### PR TITLE
refactor(remoteauth): use KRT for fetched artifacts

### DIFF
--- a/controller/pkg/agentgateway/jwks/cache.go
+++ b/controller/pkg/agentgateway/jwks/cache.go
@@ -11,11 +11,11 @@ import (
 )
 
 // JwksResults stores fetched JWKS keysets as a KRT-visible collection.
-type JwksResults = remotecache.Results[Keyset]
+type JwksResults = remotecache.FetchedResults[Keyset]
 
-// NewResults constructs an empty JWKS result collection.
-func NewResults() *JwksResults {
-	return remotecache.NewResults[Keyset]()
+// NewFetchedResults constructs an empty JWKS fetched-result collection.
+func NewFetchedResults() *JwksResults {
+	return remotecache.NewFetchedResults[Keyset]()
 }
 
 func buildKeyset(requestKey remotehttp.FetchKey, requestURL string, jwks jose.JSONWebKeySet) (Keyset, error) {

--- a/controller/pkg/agentgateway/jwks/cache.go
+++ b/controller/pkg/agentgateway/jwks/cache.go
@@ -10,12 +10,12 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
 )
 
-// JwksCache stores fetched JWKS keysets by request key.
-type JwksCache = remotecache.MapCache[Keyset]
+// JwksResults stores fetched JWKS keysets as a KRT-visible collection.
+type JwksResults = remotecache.Results[Keyset]
 
-// NewCache constructs an empty JwksCache.
-func NewCache() *JwksCache {
-	return remotecache.NewMapCache[Keyset]()
+// NewResults constructs an empty JWKS result collection.
+func NewResults() *JwksResults {
+	return remotecache.NewResults[Keyset]()
 }
 
 func buildKeyset(requestKey remotehttp.FetchKey, requestURL string, jwks jose.JSONWebKeySet) (Keyset, error) {

--- a/controller/pkg/agentgateway/jwks/collections.go
+++ b/controller/pkg/agentgateway/jwks/collections.go
@@ -51,13 +51,15 @@ func NewCollections(inputs CollectionInputs) Collections {
 		}
 	}, inputs.KrtOpts.ToOptions("JwksSources/primary")...)
 
-	sourcesByRequestKey := krt.NewIndex(primarySources, "jwks-request-key", func(source JwksSource) []remotehttp.FetchKey {
-		return []remotehttp.FetchKey{source.RequestKey}
-	})
-	requestGroups := sourcesByRequestKey.AsCollection(append(inputs.KrtOpts.ToOptions("JwksRequestGroups"), remotecache.FetchKeyIndexCollectionOption)...)
-	sharedRequests := krt.NewCollection(requestGroups, func(kctx krt.HandlerContext, grouped krt.IndexObject[remotehttp.FetchKey, JwksSource]) *SharedJwksRequest {
-		return collapseJwksSources(grouped)
-	}, inputs.KrtOpts.ToOptions("JwksRequests")...)
+	sharedRequests := remotecache.SharedRequests(
+		primarySources,
+		"jwks-request-key",
+		"JwksRequestGroups",
+		"JwksRequests",
+		inputs.KrtOpts,
+		func(source JwksSource) remotehttp.FetchKey { return source.RequestKey },
+		collapseJwksSources,
+	)
 
 	return Collections{
 		SharedRequests: sharedRequests,

--- a/controller/pkg/agentgateway/jwks/collections.go
+++ b/controller/pkg/agentgateway/jwks/collections.go
@@ -51,7 +51,7 @@ func NewCollections(inputs CollectionInputs) Collections {
 		}
 	}, inputs.KrtOpts.ToOptions("JwksSources/primary")...)
 
-	sharedRequests := remotecache.SharedRequests(
+	sharedRequests := remotecache.NewSharedRequestCollection(
 		primarySources,
 		"jwks-request-key",
 		"JwksRequestGroups",

--- a/controller/pkg/agentgateway/jwks/configmap_controller.go
+++ b/controller/pkg/agentgateway/jwks/configmap_controller.go
@@ -6,20 +6,20 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/logging"
 )
 
-// ConfigMapController synchronizes fetched JWKS keysets to persisted ConfigMaps.
-type ConfigMapController struct {
-	*remotecache.ConfigMapController[Keyset, PersistedEntry]
+// PersistenceController synchronizes fetched JWKS keysets to persisted ConfigMaps.
+type PersistenceController struct {
+	*remotecache.PersistenceController[Keyset, PersistedEntry]
 }
 
-func NewConfigMapController(apiClient apiclient.Client, storePrefix, deploymentNamespace string, store *Store, persistedEntries *PersistedEntries) *ConfigMapController {
-	logger := logging.New("jwks_store_config_map_controller")
-	logger.Info("creating jwks store ConfigMap controller")
+func NewPersistenceController(apiClient apiclient.Client, storePrefix, deploymentNamespace string, store *Store, persistedEntries *PersistedEntries) *PersistenceController {
+	logger := logging.New("jwks_store_persistence_controller")
+	logger.Info("creating jwks store persistence controller")
 
-	opts := remotecache.ConfigMapControllerOptions[Keyset, PersistedEntry]{
+	opts := remotecache.PersistenceControllerOptions[Keyset, PersistedEntry]{
 		ApiClient:            apiClient,
 		DeploymentNamespace:  deploymentNamespace,
-		ControllerName:       "JwksStoreConfigMapController",
-		Results:              store.Results().Collection(),
+		ControllerName:       "JwksStorePersistenceController",
+		Results:              store.FetchedResults().Collection(),
 		Entries:              persistedEntries.Collection(),
 		EntriesForRequestKey: persistedEntries.EntriesForRequestKey,
 		Serialize:            SetJwksInConfigMap,
@@ -30,7 +30,7 @@ func NewConfigMapController(apiClient apiclient.Client, storePrefix, deploymentN
 		Logger:               logger,
 	}
 
-	return &ConfigMapController{
-		ConfigMapController: remotecache.NewConfigMapController(opts),
+	return &PersistenceController{
+		PersistenceController: remotecache.NewPersistenceController(opts),
 	}
 }

--- a/controller/pkg/agentgateway/jwks/configmap_controller.go
+++ b/controller/pkg/agentgateway/jwks/configmap_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/logging"
 )
 
-// ConfigMapController synchronizes persisted JWKS keysets to ConfigMaps.
+// ConfigMapController synchronizes fetched JWKS keysets to persisted ConfigMaps.
 type ConfigMapController struct {
 	*remotecache.ConfigMapController[Keyset, PersistedEntry]
 }
@@ -19,10 +19,9 @@ func NewConfigMapController(apiClient apiclient.Client, storePrefix, deploymentN
 		ApiClient:            apiClient,
 		DeploymentNamespace:  deploymentNamespace,
 		ControllerName:       "JwksStoreConfigMapController",
-		Updates:              store.SubscribeToUpdates(),
+		Results:              store.Results().Collection(),
 		Entries:              persistedEntries.Collection(),
 		EntriesForRequestKey: persistedEntries.EntriesForRequestKey,
-		Lookup:               store.JwksByRequestKey,
 		Serialize:            SetJwksInConfigMap,
 		NameFunc:             persistedEntries.ConfigMapName,
 		LabelFunc:            persistedEntries.ConfigMapLabels,

--- a/controller/pkg/agentgateway/jwks/fetcher.go
+++ b/controller/pkg/agentgateway/jwks/fetcher.go
@@ -2,10 +2,7 @@ package jwks
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-
-	"github.com/go-jose/go-jose/v4"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotecache"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
@@ -34,17 +31,9 @@ func (d *JwksDriver) Fetch(ctx context.Context, source SharedJwksRequest) (Keyse
 	}
 
 	fetcherLogger.InfoContext(ctx, "fetching jwks", "url", source.Target.URL)
-
-	jwks, err := remotehttp.FetchJSON[jose.JSONWebKeySet](ctx, client, source.Target, "JWKS")
+	_, jwks, err := remotehttp.FetchJWKSBody(ctx, client, source.Target.URL, "JWKS")
 	if err != nil {
 		return Keyset{}, err
 	}
-	// Reject empty keysets at fetch time. An IdP returning a non-JWKS body
-	// (e.g. an error envelope as 200 OK) decodes into an empty Keys slice;
-	// persisting it would silently fail JWT validation in the dataplane.
-	if len(jwks.Keys) == 0 {
-		return Keyset{}, fmt.Errorf("JWKS response from %s contains no keys", source.Target.URL)
-	}
-
 	return buildKeyset(source.RequestKey, source.Target.URL, jwks)
 }

--- a/controller/pkg/agentgateway/jwks/fetcher.go
+++ b/controller/pkg/agentgateway/jwks/fetcher.go
@@ -15,12 +15,12 @@ import (
 var fetcherLogger = logging.New("jwks_fetcher")
 
 // Fetcher fetches and periodically refreshes remote JWKS keysets.
-// Fetched keysets are stored in JwksCache and updates are sent to subscribers.
+// Fetched keysets are published as KRT-visible Results.
 type Fetcher = remotecache.Fetcher[SharedJwksRequest, Keyset]
 
-func NewFetcher(cache *JwksCache) *Fetcher {
+func NewFetcher(results *JwksResults) *Fetcher {
 	driver := &JwksDriver{DefaultClient: remotehttp.NewDefaultFetchClient()}
-	return remotecache.NewFetcher[SharedJwksRequest, Keyset](cache, driver, fetcherLogger)
+	return remotecache.NewFetcher[SharedJwksRequest, Keyset](results, driver, fetcherLogger)
 }
 
 type JwksDriver struct {

--- a/controller/pkg/agentgateway/jwks/store.go
+++ b/controller/pkg/agentgateway/jwks/store.go
@@ -18,13 +18,13 @@ var storeLogger = logging.New("jwks_store")
 // persists, and serves keysets to translation.
 type Store struct {
 	*remotecache.Store[SharedJwksRequest, Keyset]
-	cache *JwksCache
+	results *JwksResults
 }
 
 func NewStore(requests krt.Collection[SharedJwksRequest], persistedEntries *PersistedEntries, storePrefix string) *Store {
-	cache := NewCache()
+	results := NewResults()
 	innerStore := remotecache.NewStore(remotecache.StoreOptions[SharedJwksRequest, Keyset]{
-		Fetcher:                  NewFetcher(cache),
+		Fetcher:                  NewFetcher(results),
 		Requests:                 requests,
 		Logger:                   storeLogger,
 		Hydrator:                 persistedEntries,
@@ -32,13 +32,17 @@ func NewStore(requests krt.Collection[SharedJwksRequest], persistedEntries *Pers
 	})
 
 	return &Store{
-		Store: innerStore,
-		cache: cache,
+		Store:   innerStore,
+		results: results,
 	}
 }
 
 func (s *Store) JwksByRequestKey(requestKey remotehttp.FetchKey) (Keyset, bool) {
-	return s.cache.Get(requestKey)
+	return s.results.Get(requestKey)
+}
+
+func (s *Store) Results() *JwksResults {
+	return s.results
 }
 
 func (s *Store) RunnableName() string {

--- a/controller/pkg/agentgateway/jwks/store.go
+++ b/controller/pkg/agentgateway/jwks/store.go
@@ -22,7 +22,7 @@ type Store struct {
 }
 
 func NewStore(requests krt.Collection[SharedJwksRequest], persistedEntries *PersistedEntries, storePrefix string) *Store {
-	results := NewResults()
+	results := NewFetchedResults()
 	innerStore := remotecache.NewStore(remotecache.StoreOptions[SharedJwksRequest, Keyset]{
 		Fetcher:                  NewFetcher(results),
 		Requests:                 requests,
@@ -41,7 +41,7 @@ func (s *Store) JwksByRequestKey(requestKey remotehttp.FetchKey) (Keyset, bool) 
 	return s.results.Get(requestKey)
 }
 
-func (s *Store) Results() *JwksResults {
+func (s *Store) FetchedResults() *JwksResults {
 	return s.results
 }
 

--- a/controller/pkg/agentgateway/jwks/store_test.go
+++ b/controller/pkg/agentgateway/jwks/store_test.go
@@ -221,7 +221,7 @@ func TestStoreLoadsPersistedKeysetsBeforeServing(t *testing.T) {
 	assert.Equal(t, keyset, actual)
 }
 
-func TestStoreClearsCacheWhenLastPolicyDeleted(t *testing.T) {
+func TestStoreClearsResultWhenLastPolicyDeleted(t *testing.T) {
 	krtOpts := krttest.KrtOptions(t)
 	uri := "https://issuer.example/jwks"
 	requestKey := remotehttp.FetchTarget{URL: uri}.Key()
@@ -259,20 +259,20 @@ func TestStoreClearsCacheWhenLastPolicyDeleted(t *testing.T) {
 		assert.Equal(c, 1, store.Fetcher.RequestCountForTest())
 	}, krttest.EventuallyTimeout, krttest.EventuallyPoll)
 
-	seedStoreJwksCacheForTest(store.cache, requestKey, uri)
+	seedStoreJwksResultForTest(store.results, requestKey, uri)
 	_, ok := store.JwksByRequestKey(requestKey)
-	assert.True(t, ok, "cache should be populated before policy deletion")
+	assert.True(t, ok, "result should be populated before policy deletion")
 
 	// Delete the AgentPolicy.
 	policies.Reset(nil)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		_, ok := store.JwksByRequestKey(requestKey)
-		assert.False(c, ok, "cache should be cleared when last policy is deleted")
+		assert.False(c, ok, "result should be cleared when last policy is deleted")
 	}, krttest.EventuallyTimeout, krttest.EventuallyPoll)
 }
 
-func TestStoreClearsCacheWhenAllSharedPoliciesDeleted(t *testing.T) {
+func TestStoreClearsResultWhenAllSharedPoliciesDeleted(t *testing.T) {
 	krtOpts := krttest.KrtOptions(t)
 	uri := "https://issuer.example/jwks"
 	requestKey := remotehttp.FetchTarget{URL: uri}.Key()
@@ -311,7 +311,7 @@ func TestStoreClearsCacheWhenAllSharedPoliciesDeleted(t *testing.T) {
 		assert.Equal(c, 1, store.Fetcher.RequestCountForTest())
 	}, krttest.EventuallyTimeout, krttest.EventuallyPoll)
 
-	seedStoreJwksCacheForTest(store.cache, requestKey, uri)
+	seedStoreJwksResultForTest(store.results, requestKey, uri)
 
 	policies.Reset(nil)
 
@@ -321,7 +321,7 @@ func TestStoreClearsCacheWhenAllSharedPoliciesDeleted(t *testing.T) {
 	}, krttest.EventuallyTimeout, krttest.EventuallyPoll)
 }
 
-func TestStoreClearsCacheWhenPolicyDeletedAfterWarmStart(t *testing.T) {
+func TestStoreClearsResultWhenPolicyDeletedAfterWarmStart(t *testing.T) {
 	krtOpts := krttest.KrtOptions(t)
 	uri := "https://issuer.example/jwks"
 	requestKey := remotehttp.FetchTarget{URL: uri}.Key()
@@ -374,7 +374,7 @@ func TestStoreClearsCacheWhenPolicyDeletedAfterWarmStart(t *testing.T) {
 	}, krttest.EventuallyTimeout, krttest.EventuallyPoll)
 
 	_, ok := store.JwksByRequestKey(requestKey)
-	assert.True(t, ok, "cache should be seeded from persisted ConfigMap")
+	assert.True(t, ok, "result should be seeded from persisted ConfigMap")
 
 	policies.Reset(nil)
 
@@ -384,7 +384,7 @@ func TestStoreClearsCacheWhenPolicyDeletedAfterWarmStart(t *testing.T) {
 	}, krttest.EventuallyTimeout, krttest.EventuallyPoll)
 }
 
-func TestStoreClearsOrphanCacheAtStartup(t *testing.T) {
+func TestStoreClearsOrphanResultAtStartup(t *testing.T) {
 	krtOpts := krttest.KrtOptions(t)
 	uri := "https://issuer.example/jwks"
 	requestKey := remotehttp.FetchTarget{URL: uri}.Key()
@@ -430,10 +430,10 @@ func TestStoreClearsOrphanCacheAtStartup(t *testing.T) {
 
 	assert.Eventually(t, store.HasSynced, krttest.EventuallyTimeout, krttest.EventuallyPoll)
 
-	// After sync, the orphan cache entry should be cleared.
+	// After sync, the orphan result should be cleared.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		_, ok := store.JwksByRequestKey(requestKey)
-		assert.False(c, ok, "orphan cache entry should be cleared after sync")
+		assert.False(c, ok, "orphan result should be cleared after sync")
 	}, krttest.EventuallyTimeout, krttest.EventuallyPoll)
 }
 
@@ -526,8 +526,8 @@ func testStoreSharedJwksRequest(requestURL string, ttl time.Duration) SharedJwks
 	}
 }
 
-func seedStoreJwksCacheForTest(cache *JwksCache, requestKey remotehttp.FetchKey, url string) {
-	cache.Put(Keyset{
+func seedStoreJwksResultForTest(results *JwksResults, requestKey remotehttp.FetchKey, url string) {
+	results.Put(Keyset{
 		RequestKey: requestKey,
 		URL:        url,
 		JwksJSON:   `{"keys":[]}`,

--- a/controller/pkg/agentgateway/oidc/cache.go
+++ b/controller/pkg/agentgateway/oidc/cache.go
@@ -5,9 +5,9 @@ import (
 )
 
 // OidcResults stores discovered OIDC providers as a KRT-visible collection.
-type OidcResults = remotecache.Results[DiscoveredProvider]
+type OidcResults = remotecache.FetchedResults[DiscoveredProvider]
 
-// NewResults constructs an empty OIDC result collection.
-func NewResults() *OidcResults {
-	return remotecache.NewResults[DiscoveredProvider]()
+// NewFetchedResults constructs an empty OIDC fetched-result collection.
+func NewFetchedResults() *OidcResults {
+	return remotecache.NewFetchedResults[DiscoveredProvider]()
 }

--- a/controller/pkg/agentgateway/oidc/cache.go
+++ b/controller/pkg/agentgateway/oidc/cache.go
@@ -4,10 +4,10 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotecache"
 )
 
-// OidcCache stores discovered OIDC providers by request key.
-type OidcCache = remotecache.MapCache[DiscoveredProvider]
+// OidcResults stores discovered OIDC providers as a KRT-visible collection.
+type OidcResults = remotecache.Results[DiscoveredProvider]
 
-// NewCache constructs an empty OidcCache.
-func NewCache() *OidcCache {
-	return remotecache.NewMapCache[DiscoveredProvider]()
+// NewResults constructs an empty OIDC result collection.
+func NewResults() *OidcResults {
+	return remotecache.NewResults[DiscoveredProvider]()
 }

--- a/controller/pkg/agentgateway/oidc/collections.go
+++ b/controller/pkg/agentgateway/oidc/collections.go
@@ -49,14 +49,15 @@ func NewCollections(inputs CollectionInputs) Collections {
 		return sources
 	}, inputs.KrtOpts.ToOptions("oidc/sources")...)
 
-	sourcesByRequestKey := krt.NewIndex(sources, "oidc-request-key", func(source OidcSource) []remotehttp.FetchKey {
-		return []remotehttp.FetchKey{source.RequestKey}
-	})
-	requestGroups := sourcesByRequestKey.AsCollection(append(inputs.KrtOpts.ToOptions("oidc/requestGroups"), remotecache.FetchKeyIndexCollectionOption)...)
-
-	sharedRequests := krt.NewCollection(requestGroups, func(ctx krt.HandlerContext, grouped krt.IndexObject[remotehttp.FetchKey, OidcSource]) *SharedOidcRequest {
-		return collapseOidcSources(grouped)
-	}, inputs.KrtOpts.ToOptions("oidc/sharedRequests")...)
+	sharedRequests := remotecache.SharedRequests(
+		sources,
+		"oidc-request-key",
+		"oidc/requestGroups",
+		"oidc/sharedRequests",
+		inputs.KrtOpts,
+		func(source OidcSource) remotehttp.FetchKey { return source.RequestKey },
+		collapseOidcSources,
+	)
 
 	return Collections{
 		SharedRequests: sharedRequests,

--- a/controller/pkg/agentgateway/oidc/collections.go
+++ b/controller/pkg/agentgateway/oidc/collections.go
@@ -49,7 +49,7 @@ func NewCollections(inputs CollectionInputs) Collections {
 		return sources
 	}, inputs.KrtOpts.ToOptions("oidc/sources")...)
 
-	sharedRequests := remotecache.SharedRequests(
+	sharedRequests := remotecache.NewSharedRequestCollection(
 		sources,
 		"oidc-request-key",
 		"oidc/requestGroups",

--- a/controller/pkg/agentgateway/oidc/configmap_controller.go
+++ b/controller/pkg/agentgateway/oidc/configmap_controller.go
@@ -6,13 +6,13 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/logging"
 )
 
-// ConfigMapController synchronizes fetched OIDC providers to persisted ConfigMaps.
-type ConfigMapController struct {
-	*remotecache.ConfigMapController[DiscoveredProvider, PersistedEntry]
+// PersistenceController synchronizes fetched OIDC providers to persisted ConfigMaps.
+type PersistenceController struct {
+	*remotecache.PersistenceController[DiscoveredProvider, PersistedEntry]
 }
 
-// ConfigMapControllerOptions configures NewConfigMapController.
-type ConfigMapControllerOptions struct {
+// PersistenceControllerOptions configures NewPersistenceController.
+type PersistenceControllerOptions struct {
 	APIClient           apiclient.Client
 	StorePrefix         string
 	DeploymentNamespace string
@@ -20,15 +20,15 @@ type ConfigMapControllerOptions struct {
 	PersistedEntries    *PersistedEntries
 }
 
-func NewConfigMapController(opts ConfigMapControllerOptions) *ConfigMapController {
-	logger := logging.New("oidc_store_config_map_controller")
-	logger.Info("creating oidc store ConfigMap controller")
+func NewPersistenceController(opts PersistenceControllerOptions) *PersistenceController {
+	logger := logging.New("oidc_store_persistence_controller")
+	logger.Info("creating oidc store persistence controller")
 
-	cacheOpts := remotecache.ConfigMapControllerOptions[DiscoveredProvider, PersistedEntry]{
+	controllerOpts := remotecache.PersistenceControllerOptions[DiscoveredProvider, PersistedEntry]{
 		ApiClient:            opts.APIClient,
 		DeploymentNamespace:  opts.DeploymentNamespace,
-		ControllerName:       "OidcStoreConfigMapController",
-		Results:              opts.Store.Results().Collection(),
+		ControllerName:       "OidcStorePersistenceController",
+		Results:              opts.Store.FetchedResults().Collection(),
 		Entries:              opts.PersistedEntries.Collection(),
 		EntriesForRequestKey: opts.PersistedEntries.EntriesForRequestKey,
 		Serialize:            SetProviderInConfigMap,
@@ -39,7 +39,7 @@ func NewConfigMapController(opts ConfigMapControllerOptions) *ConfigMapControlle
 		Logger:               logger,
 	}
 
-	return &ConfigMapController{
-		ConfigMapController: remotecache.NewConfigMapController(cacheOpts),
+	return &PersistenceController{
+		PersistenceController: remotecache.NewPersistenceController(controllerOpts),
 	}
 }

--- a/controller/pkg/agentgateway/oidc/configmap_controller.go
+++ b/controller/pkg/agentgateway/oidc/configmap_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/logging"
 )
 
-// ConfigMapController synchronizes persisted OIDC providers to ConfigMaps.
+// ConfigMapController synchronizes fetched OIDC providers to persisted ConfigMaps.
 type ConfigMapController struct {
 	*remotecache.ConfigMapController[DiscoveredProvider, PersistedEntry]
 }
@@ -28,10 +28,9 @@ func NewConfigMapController(opts ConfigMapControllerOptions) *ConfigMapControlle
 		ApiClient:            opts.APIClient,
 		DeploymentNamespace:  opts.DeploymentNamespace,
 		ControllerName:       "OidcStoreConfigMapController",
-		Updates:              opts.Store.SubscribeToUpdates(),
+		Results:              opts.Store.Results().Collection(),
 		Entries:              opts.PersistedEntries.Collection(),
 		EntriesForRequestKey: opts.PersistedEntries.EntriesForRequestKey,
-		Lookup:               opts.Store.ProviderByRequestKey,
 		Serialize:            SetProviderInConfigMap,
 		NameFunc:             opts.PersistedEntries.ConfigMapName,
 		LabelFunc:            opts.PersistedEntries.ConfigMapLabels,

--- a/controller/pkg/agentgateway/oidc/fetcher.go
+++ b/controller/pkg/agentgateway/oidc/fetcher.go
@@ -26,11 +26,12 @@ type discoveryDocument struct {
 }
 
 // Fetcher fetches and periodically refreshes OIDC discovery documents.
+// Fetched providers are published as KRT-visible Results.
 type Fetcher = remotecache.Fetcher[SharedOidcRequest, DiscoveredProvider]
 
-func NewFetcher(cache *OidcCache) *Fetcher {
+func NewFetcher(results *OidcResults) *Fetcher {
 	driver := &OidcDriver{DefaultClient: remotehttp.NewDefaultFetchClient()}
-	return remotecache.NewFetcher[SharedOidcRequest, DiscoveredProvider](cache, driver, fetcherLogger)
+	return remotecache.NewFetcher[SharedOidcRequest, DiscoveredProvider](results, driver, fetcherLogger)
 }
 
 type OidcDriver struct {

--- a/controller/pkg/agentgateway/oidc/fetcher.go
+++ b/controller/pkg/agentgateway/oidc/fetcher.go
@@ -2,13 +2,10 @@ package oidc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"time"
-
-	"github.com/go-jose/go-jose/v4"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotecache"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
@@ -50,21 +47,9 @@ func (d *OidcDriver) Fetch(ctx context.Context, source SharedOidcRequest) (Disco
 	}
 
 	fetcherLogger.InfoContext(ctx, "fetching oidc jwks", "url", doc.JwksURI)
-	jwksBody, err := remotehttp.FetchBody(ctx, d.DefaultClient, doc.JwksURI, "OIDC JWKS")
+	jwksBody, _, err := remotehttp.FetchJWKSBody(ctx, d.DefaultClient, doc.JwksURI, "OIDC JWKS")
 	if err != nil {
 		return DiscoveredProvider{}, fmt.Errorf("failed to fetch OIDC JWKS from %s: %w", doc.JwksURI, err)
-	}
-	// Validate the JWKS shape, not just JSON well-formedness — an IdP that
-	// returns an unrelated 200 OK body (error envelope, HTML, etc.) would
-	// otherwise be persisted to ConfigMap and fail opaquely in the dataplane.
-	// The original bytes are still stored verbatim so downstream consumers
-	// see exactly what the IdP returned.
-	var keyset jose.JSONWebKeySet
-	if err := json.Unmarshal(jwksBody, &keyset); err != nil {
-		return DiscoveredProvider{}, fmt.Errorf("OIDC JWKS response from %s is not a valid JWKS document: %w", doc.JwksURI, err)
-	}
-	if len(keyset.Keys) == 0 {
-		return DiscoveredProvider{}, fmt.Errorf("OIDC JWKS response from %s contains no keys", doc.JwksURI)
 	}
 
 	return DiscoveredProvider{

--- a/controller/pkg/agentgateway/oidc/store.go
+++ b/controller/pkg/agentgateway/oidc/store.go
@@ -17,13 +17,13 @@ var storeLogger = logging.New("oidc_store")
 // persists, and serves discovered providers to translation.
 type Store struct {
 	*remotecache.Store[SharedOidcRequest, DiscoveredProvider]
-	cache *OidcCache
+	results *OidcResults
 }
 
 func NewStore(requests krt.Collection[SharedOidcRequest], persistedEntries *PersistedEntries, storePrefix string) *Store {
-	cache := NewCache()
+	results := NewResults()
 	innerStore := remotecache.NewStore(remotecache.StoreOptions[SharedOidcRequest, DiscoveredProvider]{
-		Fetcher:                  NewFetcher(cache),
+		Fetcher:                  NewFetcher(results),
 		Requests:                 requests,
 		Logger:                   storeLogger,
 		Hydrator:                 persistedEntries,
@@ -31,16 +31,20 @@ func NewStore(requests krt.Collection[SharedOidcRequest], persistedEntries *Pers
 	})
 
 	return &Store{
-		Store: innerStore,
-		cache: cache,
+		Store:   innerStore,
+		results: results,
 	}
 }
 
-// ProviderByRequestKey is the cache view used by the ConfigMap reconciler.
-// Translation reads via Lookup.ResolveForOwner (KRT-backed) so it re-runs
-// when ConfigMaps change.
+// ProviderByRequestKey is the fetched-result view used by persistence.
+// Translation reads via Lookup.ResolveForOwner (KRT-backed persisted entries)
+// so xDS recomputes from Kubernetes-observed state.
 func (s *Store) ProviderByRequestKey(requestKey remotehttp.FetchKey) (DiscoveredProvider, bool) {
-	return s.cache.Get(requestKey)
+	return s.results.Get(requestKey)
+}
+
+func (s *Store) Results() *OidcResults {
+	return s.results
 }
 
 func (s *Store) RunnableName() string {

--- a/controller/pkg/agentgateway/oidc/store.go
+++ b/controller/pkg/agentgateway/oidc/store.go
@@ -21,7 +21,7 @@ type Store struct {
 }
 
 func NewStore(requests krt.Collection[SharedOidcRequest], persistedEntries *PersistedEntries, storePrefix string) *Store {
-	results := NewResults()
+	results := NewFetchedResults()
 	innerStore := remotecache.NewStore(remotecache.StoreOptions[SharedOidcRequest, DiscoveredProvider]{
 		Fetcher:                  NewFetcher(results),
 		Requests:                 requests,
@@ -43,7 +43,7 @@ func (s *Store) ProviderByRequestKey(requestKey remotehttp.FetchKey) (Discovered
 	return s.results.Get(requestKey)
 }
 
-func (s *Store) Results() *OidcResults {
+func (s *Store) FetchedResults() *OidcResults {
 	return s.results
 }
 

--- a/controller/pkg/agentgateway/remotecache/cache.go
+++ b/controller/pkg/agentgateway/remotecache/cache.go
@@ -1,7 +1,7 @@
 package remotecache
 
 import (
-	"sync"
+	"reflect"
 
 	"istio.io/istio/pkg/kube/krt"
 
@@ -21,7 +21,7 @@ func (r ResultRecord[R]) ResourceName() string {
 }
 
 func (r ResultRecord[R]) Equals(other ResultRecord[R]) bool {
-	return krt.Equal(r.Payload, other.Payload)
+	return reflect.DeepEqual(r.Payload, other.Payload)
 }
 
 // Results is the KRT-visible store of successfully fetched remote artifacts.
@@ -29,7 +29,6 @@ func (r ResultRecord[R]) Equals(other ResultRecord[R]) bool {
 // output is published as a normal KRT collection instead of a private cache
 // plus custom fanout.
 type Results[R Result] struct {
-	mu         sync.Mutex
 	collection krt.StaticCollection[ResultRecord[R]]
 }
 

--- a/controller/pkg/agentgateway/remotecache/cache.go
+++ b/controller/pkg/agentgateway/remotecache/cache.go
@@ -8,42 +8,42 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
 )
 
-// ResultRecord wraps a fetched remote artifact so it has a stable KRT key.
+// FetchedRecord wraps a fetched remote artifact so it has a stable KRT key.
 // The payload remains the domain result type; the wrapper is only the
 // KRT-visible publication envelope used by the fetch runtime and persistence
 // reconciler.
-type ResultRecord[R Result] struct {
+type FetchedRecord[R Result] struct {
 	Payload R
 }
 
-func (r ResultRecord[R]) ResourceName() string {
+func (r FetchedRecord[R]) ResourceName() string {
 	return string(r.Payload.RemoteRequestKey())
 }
 
-func (r ResultRecord[R]) Equals(other ResultRecord[R]) bool {
+func (r FetchedRecord[R]) Equals(other FetchedRecord[R]) bool {
 	return reflect.DeepEqual(r.Payload, other.Payload)
 }
 
-// Results is the KRT-visible store of successfully fetched remote artifacts.
-// The fetcher is still imperative for HTTP, retry and TTL scheduling, but its
-// output is published as a normal KRT collection instead of a private cache
-// plus custom fanout.
-type Results[R Result] struct {
-	collection krt.StaticCollection[ResultRecord[R]]
+// FetchedResults is the KRT-visible store of successfully fetched remote
+// artifacts. The fetcher is still imperative for HTTP, retry and TTL
+// scheduling, but its output is published as a normal KRT collection instead
+// of a private cache plus custom fanout.
+type FetchedResults[R Result] struct {
+	collection krt.StaticCollection[FetchedRecord[R]]
 }
 
-// NewResults constructs an empty, already-synced fetched-result collection.
-func NewResults[R Result](opts ...krt.CollectionOption) *Results[R] {
-	return &Results[R]{
+// NewFetchedResults constructs an empty, already-synced fetched-result collection.
+func NewFetchedResults[R Result](opts ...krt.CollectionOption) *FetchedResults[R] {
+	return &FetchedResults[R]{
 		collection: krt.NewStaticCollection(alwaysSynced{}, nil, opts...),
 	}
 }
 
-func (r *Results[R]) Collection() krt.Collection[ResultRecord[R]] {
+func (r *FetchedResults[R]) Collection() krt.Collection[FetchedRecord[R]] {
 	return r.collection
 }
 
-func (r *Results[R]) Get(key remotehttp.FetchKey) (R, bool) {
+func (r *FetchedResults[R]) Get(key remotehttp.FetchKey) (R, bool) {
 	var zero R
 	obj := r.collection.GetKey(string(key))
 	if obj == nil {
@@ -52,11 +52,11 @@ func (r *Results[R]) Get(key remotehttp.FetchKey) (R, bool) {
 	return obj.Payload, true
 }
 
-func (r *Results[R]) Put(result R) {
-	r.collection.UpdateObject(ResultRecord[R]{Payload: result})
+func (r *FetchedResults[R]) Put(result R) {
+	r.collection.UpdateObject(FetchedRecord[R]{Payload: result})
 }
 
-func (r *Results[R]) Delete(key remotehttp.FetchKey) bool {
+func (r *FetchedResults[R]) Delete(key remotehttp.FetchKey) bool {
 	_, existed := r.Get(key)
 	if existed {
 		r.collection.DeleteObject(string(key))
@@ -64,14 +64,14 @@ func (r *Results[R]) Delete(key remotehttp.FetchKey) bool {
 	return existed
 }
 
-func (r *Results[R]) DeleteObjects(filter func(ResultRecord[R]) bool) {
+func (r *FetchedResults[R]) DeleteObjects(filter func(FetchedRecord[R]) bool) {
 	r.collection.DeleteObjects(filter)
 }
 
-func (r *Results[R]) Reset(results []R) {
-	records := make([]ResultRecord[R], 0, len(results))
+func (r *FetchedResults[R]) Reset(results []R) {
+	records := make([]FetchedRecord[R], 0, len(results))
 	for _, result := range results {
-		records = append(records, ResultRecord[R]{Payload: result})
+		records = append(records, FetchedRecord[R]{Payload: result})
 	}
 	r.collection.Reset(records)
 }

--- a/controller/pkg/agentgateway/remotecache/cache.go
+++ b/controller/pkg/agentgateway/remotecache/cache.go
@@ -64,13 +64,8 @@ func (r *Results[R]) Delete(key remotehttp.FetchKey) bool {
 	return existed
 }
 
-func (r *Results[R]) Keys() []remotehttp.FetchKey {
-	objects := r.collection.List()
-	keys := make([]remotehttp.FetchKey, 0, len(objects))
-	for _, obj := range objects {
-		keys = append(keys, obj.Payload.RemoteRequestKey())
-	}
-	return keys
+func (r *Results[R]) DeleteObjects(filter func(ResultRecord[R]) bool) {
+	r.collection.DeleteObjects(filter)
 }
 
 func (r *Results[R]) Reset(results []R) {

--- a/controller/pkg/agentgateway/remotecache/cache.go
+++ b/controller/pkg/agentgateway/remotecache/cache.go
@@ -3,48 +3,94 @@ package remotecache
 import (
 	"sync"
 
+	"istio.io/istio/pkg/kube/krt"
+
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
 )
 
-// MapCache is a thread-safe in-memory cache of remote fetch results keyed by
-// FetchKey. Implements Cache[R].
-type MapCache[R Result] struct {
-	mu      sync.Mutex
-	entries map[remotehttp.FetchKey]R
+// ResultRecord wraps a fetched remote artifact so it has a stable KRT key.
+// The payload remains the domain result type; the wrapper is only the
+// KRT-visible publication envelope used by the fetch runtime and persistence
+// reconciler.
+type ResultRecord[R Result] struct {
+	Payload R
 }
 
-// NewMapCache constructs an empty MapCache[R].
-func NewMapCache[R Result]() *MapCache[R] {
-	return &MapCache[R]{entries: make(map[remotehttp.FetchKey]R)}
+func (r ResultRecord[R]) ResourceName() string {
+	return string(r.Payload.RemoteRequestKey())
 }
 
-func (c *MapCache[R]) Get(key remotehttp.FetchKey) (R, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	r, ok := c.entries[key]
-	return r, ok
+func (r ResultRecord[R]) Equals(other ResultRecord[R]) bool {
+	return krt.Equal(r.Payload, other.Payload)
 }
 
-func (c *MapCache[R]) Put(result R) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.entries[result.RemoteRequestKey()] = result
+// Results is the KRT-visible store of successfully fetched remote artifacts.
+// The fetcher is still imperative for HTTP, retry and TTL scheduling, but its
+// output is published as a normal KRT collection instead of a private cache
+// plus custom fanout.
+type Results[R Result] struct {
+	mu         sync.Mutex
+	collection krt.StaticCollection[ResultRecord[R]]
 }
 
-func (c *MapCache[R]) Delete(key remotehttp.FetchKey) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	_, existed := c.entries[key]
-	delete(c.entries, key)
+// NewResults constructs an empty, already-synced fetched-result collection.
+func NewResults[R Result](opts ...krt.CollectionOption) *Results[R] {
+	return &Results[R]{
+		collection: krt.NewStaticCollection(alwaysSynced{}, nil, opts...),
+	}
+}
+
+func (r *Results[R]) Collection() krt.Collection[ResultRecord[R]] {
+	return r.collection
+}
+
+func (r *Results[R]) Get(key remotehttp.FetchKey) (R, bool) {
+	var zero R
+	obj := r.collection.GetKey(string(key))
+	if obj == nil {
+		return zero, false
+	}
+	return obj.Payload, true
+}
+
+func (r *Results[R]) Put(result R) {
+	r.collection.UpdateObject(ResultRecord[R]{Payload: result})
+}
+
+func (r *Results[R]) Delete(key remotehttp.FetchKey) bool {
+	_, existed := r.Get(key)
+	if existed {
+		r.collection.DeleteObject(string(key))
+	}
 	return existed
 }
 
-func (c *MapCache[R]) Keys() []remotehttp.FetchKey {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	keys := make([]remotehttp.FetchKey, 0, len(c.entries))
-	for k := range c.entries {
-		keys = append(keys, k)
+func (r *Results[R]) Keys() []remotehttp.FetchKey {
+	objects := r.collection.List()
+	keys := make([]remotehttp.FetchKey, 0, len(objects))
+	for _, obj := range objects {
+		keys = append(keys, obj.Payload.RemoteRequestKey())
 	}
 	return keys
+}
+
+func (r *Results[R]) Reset(results []R) {
+	records := make([]ResultRecord[R], 0, len(results))
+	for _, result := range results {
+		records = append(records, ResultRecord[R]{Payload: result})
+	}
+	r.collection.Reset(records)
+}
+
+type alwaysSynced struct{}
+
+func (alwaysSynced) HasSynced() bool { return true }
+
+func (alwaysSynced) WaitUntilSynced(stop <-chan struct{}) bool {
+	select {
+	case <-stop:
+		return false
+	default:
+		return true
+	}
 }

--- a/controller/pkg/agentgateway/remotecache/collapse.go
+++ b/controller/pkg/agentgateway/remotecache/collapse.go
@@ -4,7 +4,11 @@ import (
 	"cmp"
 	"time"
 
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/slices"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
+	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil"
 )
 
 // CollapseSources merges per-owner sources sharing a fetch key into a single
@@ -26,4 +30,30 @@ func CollapseSources[S any](sources []S, ownerKey func(S) string, ttl func(S) ti
 		}
 	}
 	return primary, minTTL
+}
+
+// SharedRequests groups per-owner sources by FetchKey and collapses each group
+// into the single request the remote fetch runtime should manage. This captures
+// the standard KRT graph used by JWKS and OIDC:
+//
+//     source collection -> request-key index -> grouped index collection -> request collection
+//
+// Subsystems keep only the domain-specific source production and collapse
+// semantics, while the KRT grouping pipeline stays shared and idiomatic.
+func SharedRequests[S any, R any](
+	sources krt.Collection[S],
+	indexName string,
+	groupsName string,
+	requestsName string,
+	krtOpts krtutil.KrtOptions,
+	requestKey func(S) remotehttp.FetchKey,
+	collapse func(krt.IndexObject[remotehttp.FetchKey, S]) *R,
+) krt.Collection[R] {
+	byRequestKey := krt.NewIndex(sources, indexName, func(source S) []remotehttp.FetchKey {
+		return []remotehttp.FetchKey{requestKey(source)}
+	})
+	groups := byRequestKey.AsCollection(append(krtOpts.ToOptions(groupsName), FetchKeyIndexCollectionOption)...)
+	return krt.NewCollection(groups, func(kctx krt.HandlerContext, grouped krt.IndexObject[remotehttp.FetchKey, S]) *R {
+		return collapse(grouped)
+	}, krtOpts.ToOptions(requestsName)...)
 }

--- a/controller/pkg/agentgateway/remotecache/collapse.go
+++ b/controller/pkg/agentgateway/remotecache/collapse.go
@@ -32,15 +32,15 @@ func CollapseSources[S any](sources []S, ownerKey func(S) string, ttl func(S) ti
 	return primary, minTTL
 }
 
-// SharedRequests groups per-owner sources by FetchKey and collapses each group
-// into the single request the remote fetch runtime should manage. This captures
-// the standard KRT graph used by JWKS and OIDC:
+// NewSharedRequestCollection groups per-owner sources by FetchKey and collapses
+// each group into the single request the remote fetch runtime should manage.
+// This captures the standard KRT graph used by JWKS and OIDC:
 //
 //     source collection -> request-key index -> grouped index collection -> request collection
 //
 // Subsystems keep only the domain-specific source production and collapse
 // semantics, while the KRT grouping pipeline stays shared and idiomatic.
-func SharedRequests[S any, R any](
+func NewSharedRequestCollection[S any, R any](
 	sources krt.Collection[S],
 	indexName string,
 	groupsName string,

--- a/controller/pkg/agentgateway/remotecache/collapse_test.go
+++ b/controller/pkg/agentgateway/remotecache/collapse_test.go
@@ -1,0 +1,135 @@
+package remotecache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
+	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil"
+	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil/krttest"
+)
+
+type collapseTestSource struct {
+	Owner string
+	Key   remotehttp.FetchKey
+	TTL   time.Duration
+}
+
+type collapseTestRequest struct {
+	RequestKey remotehttp.FetchKey
+	Owner      string
+	TTL        time.Duration
+}
+
+func TestNewSharedRequestCollectionCollapsesByFetchKey(t *testing.T) {
+	krtOpts := krttest.KrtOptions(t)
+	sources := krttest.NewStaticCollection(t, []collapseTestSource{
+		{Owner: "z-owner", Key: "shared", TTL: 10 * time.Minute},
+		{Owner: "a-owner", Key: "shared", TTL: 5 * time.Minute},
+		{Owner: "other", Key: "other", TTL: 30 * time.Minute},
+	}, krtOpts, "CollapseSources")
+
+	requests := NewSharedRequestCollection(
+		sources,
+		"ByRequestKey",
+		"GroupedRequests",
+		"SharedRequests",
+		krtOpts,
+		func(source collapseTestSource) remotehttp.FetchKey {
+			return source.Key
+		},
+		func(grouped krt.IndexObject[remotehttp.FetchKey, collapseTestSource]) *collapseTestRequest {
+			primary, ttl := CollapseSources(grouped.Objects, func(source collapseTestSource) string {
+				return source.Owner
+			}, func(source collapseTestSource) time.Duration {
+				return source.TTL
+			})
+			return &collapseTestRequest{
+				RequestKey: grouped.Key,
+				Owner:      primary.Owner,
+				TTL:        ttl,
+			}
+		},
+	)
+
+	collapsed := krttest.Await(t, requests, 2)
+	byKey := make(map[remotehttp.FetchKey]collapseTestRequest, len(collapsed))
+	for _, request := range collapsed {
+		byKey[request.RequestKey] = request
+	}
+
+	require.Contains(t, byKey, remotehttp.FetchKey("shared"))
+	assert.Equal(t, "a-owner", byKey["shared"].Owner)
+	assert.Equal(t, 5*time.Minute, byKey["shared"].TTL)
+
+	require.Contains(t, byKey, remotehttp.FetchKey("other"))
+	assert.Equal(t, "other", byKey["other"].Owner)
+}
+
+func TestCollapseSourcesUsesStableOwnerOrderingAndMinTTL(t *testing.T) {
+	primary, ttl := CollapseSources([]collapseTestSource{
+		{Owner: "z-owner", TTL: 20 * time.Minute},
+		{Owner: "a-owner", TTL: 5 * time.Minute},
+		{Owner: "m-owner", TTL: 10 * time.Minute},
+	}, func(source collapseTestSource) string {
+		return source.Owner
+	}, func(source collapseTestSource) time.Duration {
+		return source.TTL
+	})
+
+	assert.Equal(t, "a-owner", primary.Owner)
+	assert.Equal(t, 5*time.Minute, ttl)
+}
+
+func TestNewSharedRequestCollectionRecomputesOnSourceReset(t *testing.T) {
+	krtOpts := krttest.KrtOptions(t)
+	sources := krttest.NewStaticCollection(t, []collapseTestSource{
+		{Owner: "owner-a", Key: "shared", TTL: 5 * time.Minute},
+	}, krtOpts, "DynamicSources")
+
+	requests := NewSharedRequestCollection(
+		sources,
+		"ByRequestKey",
+		"GroupedRequests",
+		"SharedRequests",
+		krtOpts,
+		func(source collapseTestSource) remotehttp.FetchKey {
+			return source.Key
+		},
+		func(grouped krt.IndexObject[remotehttp.FetchKey, collapseTestSource]) *collapseTestRequest {
+			primary, ttl := CollapseSources(grouped.Objects, func(source collapseTestSource) string {
+				return source.Owner
+			}, func(source collapseTestSource) time.Duration {
+				return source.TTL
+			})
+			return &collapseTestRequest{
+				RequestKey: grouped.Key,
+				Owner:      primary.Owner,
+				TTL:        ttl,
+			}
+		},
+	)
+
+	initial := krttest.Await(t, requests, 1)
+	assert.Equal(t, "owner-a", initial[0].Owner)
+
+	sources.Reset([]collapseTestSource{
+		{Owner: "owner-b", Key: "shared", TTL: 1 * time.Minute},
+	})
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		updated := krttest.Await(t, requests, 1)
+		assert.Equal(c, "owner-b", updated[0].Owner)
+		assert.Equal(c, 1*time.Minute, updated[0].TTL)
+	}, krttest.EventuallyTimeout, krttest.EventuallyPoll)
+}
+
+var _ krt.ResourceNamer = collapseTestRequest{}
+
+func (c collapseTestRequest) ResourceName() string {
+	return string(c.RequestKey)
+}

--- a/controller/pkg/agentgateway/remotecache/configmap_controller.go
+++ b/controller/pkg/agentgateway/remotecache/configmap_controller.go
@@ -36,15 +36,16 @@ type PersistedRecord interface {
 	GetName() string
 }
 
-// ConfigMapController reconciles fetched KRT result records to ConfigMaps.
-// Both inputs are KRT collections: Results is produced by the remote fetch edge,
-// while Entries is the Kubernetes-observed persisted ConfigMap view. The only
-// imperative part left here is the Kubernetes write/delete side effect.
-type ConfigMapController[T Result, E PersistedRecord] struct {
+// PersistenceController reconciles fetched KRT records to persisted
+// ConfigMaps. Both inputs are KRT collections: fetched results are produced by
+// the remote fetch edge, while entries are the Kubernetes-observed persisted
+// ConfigMap view. The only imperative part left here is the Kubernetes
+// write/delete side effect.
+type PersistenceController[T Result, E PersistedRecord] struct {
 	apiClient            apiclient.Client
 	cmClient             kclient.Client[*corev1.ConfigMap]
 	eventQueue           controllers.Queue
-	results              krt.Collection[ResultRecord[T]]
+	results              krt.Collection[FetchedRecord[T]]
 	entries              krt.Collection[E]
 	entriesForRequestKey func(remotehttp.FetchKey) []E
 	serialize            func(*corev1.ConfigMap, T) error
@@ -59,11 +60,11 @@ type ConfigMapController[T Result, E PersistedRecord] struct {
 	logger               *slog.Logger
 }
 
-type ConfigMapControllerOptions[T Result, E PersistedRecord] struct {
+type PersistenceControllerOptions[T Result, E PersistedRecord] struct {
 	ApiClient            apiclient.Client
 	DeploymentNamespace  string
 	ControllerName       string
-	Results              krt.Collection[ResultRecord[T]]
+	Results              krt.Collection[FetchedRecord[T]]
 	Entries              krt.Collection[E]
 	EntriesForRequestKey func(remotehttp.FetchKey) []E
 	Serialize            func(*corev1.ConfigMap, T) error
@@ -74,8 +75,8 @@ type ConfigMapControllerOptions[T Result, E PersistedRecord] struct {
 	Logger               *slog.Logger
 }
 
-func NewConfigMapController[T Result, E PersistedRecord](opts ConfigMapControllerOptions[T, E]) *ConfigMapController[T, E] {
-	return &ConfigMapController[T, E]{
+func NewPersistenceController[T Result, E PersistedRecord](opts PersistenceControllerOptions[T, E]) *PersistenceController[T, E] {
+	return &PersistenceController[T, E]{
 		apiClient:            opts.ApiClient,
 		deploymentNamespace:  opts.DeploymentNamespace,
 		controllerName:       opts.ControllerName,
@@ -92,7 +93,7 @@ func NewConfigMapController[T Result, E PersistedRecord](opts ConfigMapControlle
 	}
 }
 
-func (c *ConfigMapController[T, E]) Init(ctx context.Context) {
+func (c *PersistenceController[T, E]) Init(ctx context.Context) {
 	c.cmClient = kclient.NewFiltered[*corev1.ConfigMap](c.apiClient,
 		kclient.Filter{
 			ObjectFilter:  c.apiClient.ObjectFilter(),
@@ -110,7 +111,7 @@ func (c *ConfigMapController[T, E]) Init(ctx context.Context) {
 	)
 }
 
-func (c *ConfigMapController[T, E]) Start(ctx context.Context) error {
+func (c *PersistenceController[T, E]) Start(ctx context.Context) error {
 	c.reconcileCtx = ctx
 
 	c.logger.Info("waiting for cache to sync")
@@ -120,11 +121,11 @@ func (c *ConfigMapController[T, E]) Start(ctx context.Context) error {
 		c.waitForSync...,
 	)
 
-	c.logger.Info("starting ConfigMap controller")
-	resultRegistration := c.results.RegisterBatch(func(events []krt.Event[ResultRecord[T]]) {
+	c.logger.Info("starting persistence controller")
+	resultRegistration := c.results.RegisterBatch(func(events []krt.Event[FetchedRecord[T]]) {
 		for _, event := range events {
-			c.enqueueResultRecord(event.Old)
-			c.enqueueResultRecord(event.New)
+			c.enqueueFetchedRecord(event.Old)
+			c.enqueueFetchedRecord(event.New)
 		}
 	}, true)
 	defer resultRegistration.UnregisterHandler()
@@ -150,7 +151,7 @@ func (c *ConfigMapController[T, E]) Start(ctx context.Context) error {
 	return nil
 }
 
-func (c *ConfigMapController[T, E]) Reconcile(req types.NamespacedName) error {
+func (c *PersistenceController[T, E]) Reconcile(req types.NamespacedName) error {
 	c.logger.Debug("syncing fetched result to ConfigMap(s)")
 	ctx := c.reconcileCtx
 	requestKey := remotehttp.FetchKey(req.Name)
@@ -187,11 +188,11 @@ func (c *ConfigMapController[T, E]) Reconcile(req types.NamespacedName) error {
 	return nil
 }
 
-func (c *ConfigMapController[T, E]) NeedLeaderElection() bool {
+func (c *PersistenceController[T, E]) NeedLeaderElection() bool {
 	return true
 }
 
-func (c *ConfigMapController[T, E]) newStoreConfigMap(name string) *corev1.ConfigMap {
+func (c *PersistenceController[T, E]) newStoreConfigMap(name string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -202,14 +203,14 @@ func (c *ConfigMapController[T, E]) newStoreConfigMap(name string) *corev1.Confi
 	}
 }
 
-func (c *ConfigMapController[T, E]) enqueueResultRecord(record *ResultRecord[T]) {
+func (c *PersistenceController[T, E]) enqueueFetchedRecord(record *FetchedRecord[T]) {
 	if record == nil {
 		return
 	}
 	c.eventQueue.Add(RequestQueueKey(c.deploymentNamespace, record.Payload.RemoteRequestKey()))
 }
 
-func (c *ConfigMapController[T, E]) enqueuePersistedRecord(entry *E) {
+func (c *PersistenceController[T, E]) enqueuePersistedRecord(entry *E) {
 	if entry == nil {
 		return
 	}
@@ -220,7 +221,7 @@ func (c *ConfigMapController[T, E]) enqueuePersistedRecord(entry *E) {
 	c.eventQueue.Add(RequestQueueKey(c.deploymentNamespace, requestKey))
 }
 
-func (c *ConfigMapController[T, E]) upsertConfigMap(ctx context.Context, namespace, name string, record T) error {
+func (c *PersistenceController[T, E]) upsertConfigMap(ctx context.Context, namespace, name string, record T) error {
 	existingCm := c.cmClient.Get(name, namespace)
 	if existingCm == nil {
 		c.logger.Debug("creating ConfigMap", "name", name)

--- a/controller/pkg/agentgateway/remotecache/configmap_controller.go
+++ b/controller/pkg/agentgateway/remotecache/configmap_controller.go
@@ -10,7 +10,6 @@ import (
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/krt"
-	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,22 +29,24 @@ func newCMRateLimiter() workqueue.TypedRateLimiter[any] {
 	)
 }
 
-// PersistedRecord provides the metadata needed to reconcile a memory-backed
-// record to its ConfigMap persistence.
+// PersistedRecord provides the metadata needed to reconcile persisted
+// ConfigMaps for a fetched remote artifact.
 type PersistedRecord interface {
 	RequestKey() (remotehttp.FetchKey, bool)
 	GetName() string
 }
 
-// ConfigMapController reconciles in-memory records to ConfigMaps.
-type ConfigMapController[T any, E PersistedRecord] struct {
+// ConfigMapController reconciles fetched KRT result records to ConfigMaps.
+// Both inputs are KRT collections: Results is produced by the remote fetch edge,
+// while Entries is the Kubernetes-observed persisted ConfigMap view. The only
+// imperative part left here is the Kubernetes write/delete side effect.
+type ConfigMapController[T Result, E PersistedRecord] struct {
 	apiClient            apiclient.Client
 	cmClient             kclient.Client[*corev1.ConfigMap]
 	eventQueue           controllers.Queue
-	updates              <-chan sets.Set[remotehttp.FetchKey]
+	results              krt.Collection[ResultRecord[T]]
 	entries              krt.Collection[E]
 	entriesForRequestKey func(remotehttp.FetchKey) []E
-	lookup               func(remotehttp.FetchKey) (T, bool)
 	serialize            func(*corev1.ConfigMap, T) error
 	nameFunc             func(remotehttp.FetchKey) string
 	labelFunc            func() map[string]string
@@ -58,14 +59,13 @@ type ConfigMapController[T any, E PersistedRecord] struct {
 	logger               *slog.Logger
 }
 
-type ConfigMapControllerOptions[T any, E PersistedRecord] struct {
+type ConfigMapControllerOptions[T Result, E PersistedRecord] struct {
 	ApiClient            apiclient.Client
 	DeploymentNamespace  string
 	ControllerName       string
-	Updates              <-chan sets.Set[remotehttp.FetchKey]
+	Results              krt.Collection[ResultRecord[T]]
 	Entries              krt.Collection[E]
 	EntriesForRequestKey func(remotehttp.FetchKey) []E
-	Lookup               func(remotehttp.FetchKey) (T, bool)
 	Serialize            func(*corev1.ConfigMap, T) error
 	NameFunc             func(remotehttp.FetchKey) string
 	LabelFunc            func() map[string]string
@@ -74,21 +74,20 @@ type ConfigMapControllerOptions[T any, E PersistedRecord] struct {
 	Logger               *slog.Logger
 }
 
-func NewConfigMapController[T any, E PersistedRecord](opts ConfigMapControllerOptions[T, E]) *ConfigMapController[T, E] {
+func NewConfigMapController[T Result, E PersistedRecord](opts ConfigMapControllerOptions[T, E]) *ConfigMapController[T, E] {
 	return &ConfigMapController[T, E]{
 		apiClient:            opts.ApiClient,
 		deploymentNamespace:  opts.DeploymentNamespace,
 		controllerName:       opts.ControllerName,
-		updates:              opts.Updates,
+		results:              opts.Results,
 		entries:              opts.Entries,
 		entriesForRequestKey: opts.EntriesForRequestKey,
-		lookup:               opts.Lookup,
 		serialize:            opts.Serialize,
 		nameFunc:             opts.NameFunc,
 		labelFunc:            opts.LabelFunc,
 		labelSelector:        opts.LabelSelector,
 		rateLimiter:          newCMRateLimiter(),
-		waitForSync:          []cache.InformerSynced{opts.Entries.HasSynced, opts.StoreHasSynced},
+		waitForSync:          []cache.InformerSynced{opts.Results.HasSynced, opts.Entries.HasSynced, opts.StoreHasSynced},
 		logger:               opts.Logger,
 	}
 }
@@ -122,26 +121,27 @@ func (c *ConfigMapController[T, E]) Start(ctx context.Context) error {
 	)
 
 	c.logger.Info("starting ConfigMap controller")
-	persistedRegistration := c.entries.Register(func(event krt.Event[E]) {
-		c.enqueuePersistedRecord(event.Old)
-		c.enqueuePersistedRecord(event.New)
-	})
+	resultRegistration := c.results.RegisterBatch(func(events []krt.Event[ResultRecord[T]]) {
+		for _, event := range events {
+			c.enqueueResultRecord(event.Old)
+			c.enqueueResultRecord(event.New)
+		}
+	}, true)
+	defer resultRegistration.UnregisterHandler()
+
+	persistedRegistration := c.entries.RegisterBatch(func(events []krt.Event[E]) {
+		for _, event := range events {
+			c.enqueuePersistedRecord(event.Old)
+			c.enqueuePersistedRecord(event.New)
+		}
+	}, true)
 	defer persistedRegistration.UnregisterHandler()
 
-	go func() {
-		for {
-			select {
-			case u := <-c.updates:
-				for requestKey := range u {
-					c.eventQueue.Add(RequestQueueKey(c.deploymentNamespace, requestKey))
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
 	go c.eventQueue.Run(ctx.Done())
 
+	if !resultRegistration.WaitUntilSynced(ctx.Done()) {
+		return nil
+	}
 	if !persistedRegistration.WaitUntilSynced(ctx.Done()) {
 		return nil
 	}
@@ -151,7 +151,7 @@ func (c *ConfigMapController[T, E]) Start(ctx context.Context) error {
 }
 
 func (c *ConfigMapController[T, E]) Reconcile(req types.NamespacedName) error {
-	c.logger.Debug("syncing memory to ConfigMap(s)")
+	c.logger.Debug("syncing fetched result to ConfigMap(s)")
 	ctx := c.reconcileCtx
 	requestKey := remotehttp.FetchKey(req.Name)
 
@@ -161,9 +161,12 @@ func (c *ConfigMapController[T, E]) Reconcile(req types.NamespacedName) error {
 		existingNames = append(existingNames, entry.GetName())
 	}
 
-	record, exists := c.lookup(requestKey)
+	result := c.results.GetKey(string(requestKey))
+	var record T
+	exists := result != nil
 	var canonicalName string
 	if exists {
+		record = result.Payload
 		canonicalName = c.nameFunc(requestKey)
 	}
 
@@ -197,6 +200,13 @@ func (c *ConfigMapController[T, E]) newStoreConfigMap(name string) *corev1.Confi
 		},
 		Data: make(map[string]string),
 	}
+}
+
+func (c *ConfigMapController[T, E]) enqueueResultRecord(record *ResultRecord[T]) {
+	if record == nil {
+		return
+	}
+	c.eventQueue.Add(RequestQueueKey(c.deploymentNamespace, record.Payload.RemoteRequestKey()))
 }
 
 func (c *ConfigMapController[T, E]) enqueuePersistedRecord(entry *E) {
@@ -239,7 +249,7 @@ func (c *ConfigMapController[T, E]) upsertConfigMap(ctx context.Context, namespa
 	return nil
 }
 
-// SyncPlan represents a mechanical plan for reconciling in-memory records to ConfigMaps.
+// SyncPlan represents a mechanical plan for reconciling fetched records to ConfigMaps.
 type SyncPlan struct {
 	UpsertName  string
 	DeleteNames []string

--- a/controller/pkg/agentgateway/remotecache/fetched_results_test.go
+++ b/controller/pkg/agentgateway/remotecache/fetched_results_test.go
@@ -1,0 +1,89 @@
+package remotecache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"istio.io/istio/pkg/kube/krt"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
+	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil/krttest"
+)
+
+type fetchedResultsTestResult struct {
+	Key       remotehttp.FetchKey
+	FetchedAt time.Time
+	Value     string
+}
+
+func (r fetchedResultsTestResult) RemoteRequestKey() remotehttp.FetchKey { return r.Key }
+func (r fetchedResultsTestResult) RemoteFetchedAt() time.Time            { return r.FetchedAt }
+
+func TestFetchedResultsPublishesKRTEvents(t *testing.T) {
+	results := NewFetchedResults[fetchedResultsTestResult]()
+
+	var batches [][]krt.Event[FetchedRecord[fetchedResultsTestResult]]
+	registration := results.Collection().RegisterBatch(func(events []krt.Event[FetchedRecord[fetchedResultsTestResult]]) {
+		batches = append(batches, events)
+	}, false)
+	defer registration.UnregisterHandler()
+	require.True(t, registration.WaitUntilSynced(t.Context().Done()))
+
+	result := fetchedResultsTestResult{Key: "issuer-a", FetchedAt: time.Unix(100, 0), Value: "v1"}
+	results.Put(result)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		if assert.NotEmpty(c, batches) {
+			latest := batches[len(batches)-1]
+			assert.Len(c, latest, 1)
+			assert.NotNil(c, latest[0].New)
+			assert.Equal(c, result, latest[0].New.Payload)
+		}
+	}, krttest.EventuallyTimeout, krttest.EventuallyPoll)
+
+	got, ok := results.Get("issuer-a")
+	require.True(t, ok)
+	require.Equal(t, result, got)
+}
+
+func TestFetchedResultsDeleteRemovesRecord(t *testing.T) {
+	results := NewFetchedResults[fetchedResultsTestResult]()
+	results.Put(fetchedResultsTestResult{Key: "issuer-a", FetchedAt: time.Unix(100, 0), Value: "v1"})
+
+	require.True(t, results.Delete("issuer-a"))
+	_, ok := results.Get("issuer-a")
+	require.False(t, ok)
+	require.False(t, results.Delete("issuer-a"))
+}
+
+func TestFetchedResultsDeleteObjectsRemovesMatchingRecords(t *testing.T) {
+	results := NewFetchedResults[fetchedResultsTestResult]()
+	results.Put(fetchedResultsTestResult{Key: "keep", FetchedAt: time.Unix(100, 0), Value: "keep"})
+	results.Put(fetchedResultsTestResult{Key: "delete", FetchedAt: time.Unix(100, 0), Value: "delete"})
+
+	results.DeleteObjects(func(record FetchedRecord[fetchedResultsTestResult]) bool {
+		return record.Payload.Value == "delete"
+	})
+
+	_, ok := results.Get("delete")
+	require.False(t, ok)
+	got, ok := results.Get("keep")
+	require.True(t, ok)
+	require.Equal(t, "keep", got.Value)
+}
+
+func TestFetchedResultsResetReplacesSnapshot(t *testing.T) {
+	results := NewFetchedResults[fetchedResultsTestResult]()
+	results.Put(fetchedResultsTestResult{Key: "stale", FetchedAt: time.Unix(100, 0), Value: "stale"})
+
+	fresh := fetchedResultsTestResult{Key: "fresh", FetchedAt: time.Unix(200, 0), Value: "fresh"}
+	results.Reset([]fetchedResultsTestResult{fresh})
+
+	_, ok := results.Get("stale")
+	require.False(t, ok)
+	got, ok := results.Get("fresh")
+	require.True(t, ok)
+	require.Equal(t, fresh, got)
+}

--- a/controller/pkg/agentgateway/remotecache/fetcher.go
+++ b/controller/pkg/agentgateway/remotecache/fetcher.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"istio.io/istio/pkg/util/sets"
-
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
 )
 
@@ -23,14 +21,6 @@ type Result interface {
 	RemoteFetchedAt() time.Time
 }
 
-// Cache provides storage for fetched results.
-type Cache[R Result] interface {
-	Get(key remotehttp.FetchKey) (R, bool)
-	Put(result R)
-	Delete(key remotehttp.FetchKey) bool
-	Keys() []remotehttp.FetchKey
-}
-
 // Driver performs the actual remote fetch.
 type Driver[S Request, R Result] interface {
 	Fetch(ctx context.Context, source S) (R, error)
@@ -43,24 +33,26 @@ type InternalFetchState[S Request] struct {
 }
 
 // Fetcher manages the lifecycle of remote resource discovery and periodic refresh.
+// Fetching remains imperative because it owns timers, retries, and HTTP side
+// effects. Successful results are published into Results, which is a KRT
+// StaticCollection, so downstream persistence and translation invalidation can
+// use normal KRT event propagation rather than a parallel fanout channel.
 type Fetcher[S Request, R Result] struct {
 	mu       sync.Mutex
-	Cache    Cache[R]
+	Results  *Results[R]
 	Driver   Driver[S, R]
 	requests map[remotehttp.FetchKey]InternalFetchState[S]
 	schedule *Schedule
-	fanout   *UpdateFanout
 	wake     chan struct{}
 	logger   *slog.Logger
 }
 
-func NewFetcher[S Request, R Result](cache Cache[R], driver Driver[S, R], logger *slog.Logger) *Fetcher[S, R] {
+func NewFetcher[S Request, R Result](results *Results[R], driver Driver[S, R], logger *slog.Logger) *Fetcher[S, R] {
 	return &Fetcher[S, R]{
-		Cache:    cache,
+		Results:  results,
 		Driver:   driver,
 		requests: make(map[remotehttp.FetchKey]InternalFetchState[S]),
 		schedule: NewSchedule(),
-		fanout:   NewUpdateFanout(),
 		wake:     make(chan struct{}, 1),
 		logger:   logger,
 	}
@@ -106,7 +98,6 @@ func (f *Fetcher[S, R]) MaybeFetch(ctx context.Context) {
 		return
 	}
 
-	updates := sets.New[remotehttp.FetchKey]()
 	for _, fetch := range due {
 		state, ok := f.lookup(fetch.RequestKey)
 		if !ok || state.Generation != fetch.Generation {
@@ -125,26 +116,15 @@ func (f *Fetcher[S, R]) MaybeFetch(ctx context.Context) {
 		if !f.commitFetchResult(fetch.RequestKey, fetch.Generation, result, now.Add(state.Source.RemoteTTL())) {
 			continue
 		}
-		updates.Insert(fetch.RequestKey)
 	}
 
-	if updates.IsEmpty() {
-		return
-	}
-
-	swept := f.sweepRetiredCache()
-	updates.Merge(swept)
-	f.fanout.Notify(updates)
-}
-
-func (f *Fetcher[S, R]) SubscribeToUpdates() <-chan sets.Set[remotehttp.FetchKey] {
-	return f.fanout.Subscribe()
+	f.sweepRetiredResults()
 }
 
 func (f *Fetcher[S, R]) AddOrUpdate(source S) {
 	requestKey := source.RemoteRequestKey()
 	nextFetchAt := time.Now()
-	if cached, ok := f.Cache.Get(requestKey); ok {
+	if cached, ok := f.Results.Get(requestKey); ok {
 		if fetchedAt := cached.RemoteFetchedAt(); !fetchedAt.IsZero() {
 			expiresAt := fetchedAt.Add(source.RemoteTTL())
 			if expiresAt.After(nextFetchAt) {
@@ -170,16 +150,14 @@ func (f *Fetcher[S, R]) Remove(requestKey remotehttp.FetchKey) {
 		delete(f.requests, requestKey)
 		f.schedule.Remove(requestKey)
 	}
-	hadCache := f.Cache.Delete(requestKey)
 	f.mu.Unlock()
 
-	if !hadRequest && !hadCache {
-		return
-	}
-
-	f.fanout.Notify(sets.New(requestKey))
+	hadResult := f.Results.Delete(requestKey)
 	if hadRequest {
 		SignalWake(f.wake)
+	}
+	if !hadRequest && !hadResult {
+		return
 	}
 }
 
@@ -198,19 +176,7 @@ func (f *Fetcher[S, R]) Retire(requestKey remotehttp.FetchKey) {
 }
 
 func (f *Fetcher[S, R]) SweepOrphans() {
-	f.mu.Lock()
-	orphans := sets.New[remotehttp.FetchKey]()
-	for _, key := range f.Cache.Keys() {
-		if _, ok := f.requests[key]; !ok {
-			orphans.Insert(key)
-			f.Cache.Delete(key)
-		}
-	}
-	f.mu.Unlock()
-
-	if !orphans.IsEmpty() {
-		f.fanout.Notify(orphans)
-	}
+	f.sweepRetiredResults()
 }
 
 func (f *Fetcher[S, R]) popDue(now time.Time) []FetchAt {
@@ -235,22 +201,24 @@ func (f *Fetcher[S, R]) commitFetchResult(requestKey remotehttp.FetchKey, genera
 		return false
 	}
 
-	f.Cache.Put(result)
+	f.Results.Put(result)
 	f.scheduleAtLocked(requestKey, generation, nextFetchAt, 0)
 	return true
 }
 
-func (f *Fetcher[S, R]) sweepRetiredCache() sets.Set[remotehttp.FetchKey] {
+func (f *Fetcher[S, R]) sweepRetiredResults() {
 	f.mu.Lock()
-	swept := sets.New[remotehttp.FetchKey]()
-	for _, key := range f.Cache.Keys() {
-		if _, ok := f.requests[key]; !ok {
-			swept.Insert(key)
-			f.Cache.Delete(key)
-		}
+	live := make(map[remotehttp.FetchKey]struct{}, len(f.requests))
+	for key := range f.requests {
+		live[key] = struct{}{}
 	}
 	f.mu.Unlock()
-	return swept
+
+	for _, key := range f.Results.Keys() {
+		if _, ok := live[key]; !ok {
+			f.Results.Delete(key)
+		}
+	}
 }
 
 func (f *Fetcher[S, R]) scheduleAt(requestKey remotehttp.FetchKey, generation uint64, at time.Time, retryAttempt int) {

--- a/controller/pkg/agentgateway/remotecache/fetcher.go
+++ b/controller/pkg/agentgateway/remotecache/fetcher.go
@@ -214,11 +214,10 @@ func (f *Fetcher[S, R]) sweepRetiredResults() {
 	}
 	f.mu.Unlock()
 
-	for _, key := range f.Results.Keys() {
-		if _, ok := live[key]; !ok {
-			f.Results.Delete(key)
-		}
-	}
+	f.Results.DeleteObjects(func(record ResultRecord[R]) bool {
+		_, ok := live[record.Payload.RemoteRequestKey()]
+		return !ok
+	})
 }
 
 func (f *Fetcher[S, R]) scheduleAt(requestKey remotehttp.FetchKey, generation uint64, at time.Time, retryAttempt int) {

--- a/controller/pkg/agentgateway/remotecache/fetcher.go
+++ b/controller/pkg/agentgateway/remotecache/fetcher.go
@@ -34,12 +34,12 @@ type InternalFetchState[S Request] struct {
 
 // Fetcher manages the lifecycle of remote resource discovery and periodic refresh.
 // Fetching remains imperative because it owns timers, retries, and HTTP side
-// effects. Successful results are published into Results, which is a KRT
-// StaticCollection, so downstream persistence and translation invalidation can
-// use normal KRT event propagation rather than a parallel fanout channel.
+// effects. Successful results are published into FetchedResults, which is a
+// KRT StaticCollection, so downstream persistence and translation invalidation
+// can use normal KRT event propagation rather than a parallel fanout channel.
 type Fetcher[S Request, R Result] struct {
 	mu       sync.Mutex
-	Results  *Results[R]
+	Results  *FetchedResults[R]
 	Driver   Driver[S, R]
 	requests map[remotehttp.FetchKey]InternalFetchState[S]
 	schedule *Schedule
@@ -47,7 +47,7 @@ type Fetcher[S Request, R Result] struct {
 	logger   *slog.Logger
 }
 
-func NewFetcher[S Request, R Result](results *Results[R], driver Driver[S, R], logger *slog.Logger) *Fetcher[S, R] {
+func NewFetcher[S Request, R Result](results *FetchedResults[R], driver Driver[S, R], logger *slog.Logger) *Fetcher[S, R] {
 	return &Fetcher[S, R]{
 		Results:  results,
 		Driver:   driver,
@@ -214,7 +214,7 @@ func (f *Fetcher[S, R]) sweepRetiredResults() {
 	}
 	f.mu.Unlock()
 
-	f.Results.DeleteObjects(func(record ResultRecord[R]) bool {
+	f.Results.DeleteObjects(func(record FetchedRecord[R]) bool {
 		_, ok := live[record.Payload.RemoteRequestKey()]
 		return !ok
 	})

--- a/controller/pkg/agentgateway/remotecache/scheduler.go
+++ b/controller/pkg/agentgateway/remotecache/scheduler.go
@@ -2,10 +2,7 @@ package remotecache
 
 import (
 	"container/heap"
-	"sync"
 	"time"
-
-	"istio.io/istio/pkg/util/sets"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
 )
@@ -129,48 +126,6 @@ func NextRetryDelay(retryAttempt int) time.Duration {
 		return MaxRetryDelay
 	}
 	return next
-}
-
-// UpdateFanout manages notification to multiple subscribers. Subscribe and
-// Notify are safe to call concurrently from multiple goroutines.
-type UpdateFanout struct {
-	mu          sync.Mutex
-	subscribers []chan sets.Set[remotehttp.FetchKey]
-}
-
-func NewUpdateFanout() *UpdateFanout {
-	return &UpdateFanout{
-		subscribers: make([]chan sets.Set[remotehttp.FetchKey], 0),
-	}
-}
-
-func (f *UpdateFanout) Subscribe() <-chan sets.Set[remotehttp.FetchKey] {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	subscriber := make(chan sets.Set[remotehttp.FetchKey], 1)
-	f.subscribers = append(f.subscribers, subscriber)
-	return subscriber
-}
-
-func (f *UpdateFanout) Notify(updates sets.Set[remotehttp.FetchKey]) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	for _, subscriber := range f.subscribers {
-		merged := cloneRequestKeySet(updates)
-		select {
-		case existing := <-subscriber:
-			merged.Merge(existing)
-		default:
-		}
-		subscriber <- merged
-	}
-}
-
-func cloneRequestKeySet(updates sets.Set[remotehttp.FetchKey]) sets.Set[remotehttp.FetchKey] {
-	if updates == nil {
-		return sets.New[remotehttp.FetchKey]()
-	}
-	return updates.Copy()
 }
 
 func SignalWake(wake chan<- struct{}) {

--- a/controller/pkg/agentgateway/remotecache/scheduler_test.go
+++ b/controller/pkg/agentgateway/remotecache/scheduler_test.go
@@ -1,12 +1,10 @@
 package remotecache
 
 import (
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"istio.io/istio/pkg/util/sets"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
 )
@@ -112,75 +110,6 @@ func TestNextRetryDelayMonotonicUntilCap(t *testing.T) {
 		prev = d
 	}
 	require.True(t, hitCap, "should reach cap within 10 attempts")
-}
-
-func TestUpdateFanoutNotifyDeliversToEachSubscriber(t *testing.T) {
-	f := NewUpdateFanout()
-	a := f.Subscribe()
-	b := f.Subscribe()
-
-	f.Notify(sets.New(keyA))
-
-	require.True(t, (<-a).Contains(keyA))
-	require.True(t, (<-b).Contains(keyA))
-}
-
-func TestUpdateFanoutMergesPendingUpdates(t *testing.T) {
-	f := NewUpdateFanout()
-	updates := f.Subscribe()
-
-	f.Notify(sets.New(keyA))
-	f.Notify(sets.New(keyB))
-
-	merged := <-updates
-	require.True(t, merged.Contains(keyA))
-	require.True(t, merged.Contains(keyB))
-}
-
-func TestUpdateFanoutNotifyConcurrentSafe(t *testing.T) {
-	f := NewUpdateFanout()
-	updates := f.Subscribe()
-
-	const goroutines = 50
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	for i := range goroutines {
-		go func(i int) {
-			defer wg.Done()
-			f.Notify(sets.New(remotehttp.FetchKey(string(rune('A' + i%26)))))
-		}(i)
-	}
-	wg.Wait()
-
-	drained := false
-	for !drained {
-		select {
-		case <-updates:
-		case <-time.After(50 * time.Millisecond):
-			drained = true
-		}
-	}
-}
-
-func TestUpdateFanoutSubscribeDuringNotifyDoesNotPanic(t *testing.T) {
-	f := NewUpdateFanout()
-	f.Subscribe()
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		for range 100 {
-			f.Notify(sets.New(keyA))
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		for range 100 {
-			f.Subscribe()
-		}
-	}()
-	wg.Wait()
 }
 
 func TestSignalWakeNonBlocking(t *testing.T) {

--- a/controller/pkg/agentgateway/remotecache/store.go
+++ b/controller/pkg/agentgateway/remotecache/store.go
@@ -7,7 +7,6 @@ import (
 
 	"istio.io/istio/pkg/kube/controllers"
 	"istio.io/istio/pkg/kube/krt"
-	"istio.io/istio/pkg/util/sets"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
 )
@@ -19,8 +18,8 @@ var FetchKeyIndexCollectionOption = krt.WithIndexCollectionFromString(func(s str
 	return remotehttp.FetchKey(s)
 })
 
-// Hydrator loads previously persisted Results so the in-memory cache can
-// serve last-known-good data before any remote fetches complete on startup.
+// Hydrator loads previously persisted Results so the fetched-result collection
+// can serve last-known-good data before any remote fetches complete on startup.
 type Hydrator[R Result] interface {
 	LoadAll(ctx context.Context) ([]R, error)
 }
@@ -31,16 +30,16 @@ type StoreOptions[S Request, R Result] struct {
 	Requests krt.Collection[S]
 	Logger   *slog.Logger
 
-	// Hydrator, if non-nil, populates Fetcher.Cache before request
+	// Hydrator, if non-nil, populates Fetcher.Results before request
 	// registration. LoadAll errors are logged but never block Start so a
 	// transient persistence failure cannot stall fresh fetches.
 	Hydrator Hydrator[R]
 
 	// RetireOnRequestKeyChange, if true, calls Fetcher.Retire when a request's
-	// key changes. This stops fetching the old key but preserves its cache
-	// entry so existing traffic can continue using last-known-good data
-	// until a newer fetch for the same resource (under a different key)
-	// or an orphan sweep removes it.
+	// key changes. This stops fetching the old key but preserves its result so
+	// existing traffic can continue using last-known-good data until a newer
+	// fetch for the same resource (under a different key) or an orphan sweep
+	// removes it.
 	RetireOnRequestKeyChange bool
 }
 
@@ -65,11 +64,9 @@ func (s *Store[S, R]) Start(ctx context.Context) error {
 	if s.opts.Hydrator != nil {
 		stored, err := s.opts.Hydrator.LoadAll(ctx)
 		if err != nil {
-			s.opts.Logger.Error("error hydrating remote cache from persistence", "error", err)
+			s.opts.Logger.Error("error hydrating remote results from persistence", "error", err)
 		}
-		for _, result := range stored {
-			s.opts.Fetcher.Cache.Put(result)
-		}
+		s.opts.Fetcher.Results.Reset(stored)
 	}
 
 	registration := s.opts.Requests.Register(func(event krt.Event[S]) {
@@ -126,10 +123,6 @@ func (s *Store[S, R]) HasSynced() bool {
 	default:
 		return false
 	}
-}
-
-func (s *Store[S, R]) SubscribeToUpdates() <-chan sets.Set[remotehttp.FetchKey] {
-	return s.opts.Fetcher.SubscribeToUpdates()
 }
 
 func (s *Store[S, R]) NeedLeaderElection() bool {

--- a/controller/pkg/agentgateway/remotehttp/client.go
+++ b/controller/pkg/agentgateway/remotehttp/client.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/go-jose/go-jose/v4"
 )
 
 const ClientTimeout = 10 * time.Second
@@ -120,4 +122,32 @@ func FetchBody(ctx context.Context, client *http.Client, requestURL, description
 		return nil, fmt.Errorf("could not read %s response: %w", description, err)
 	}
 	return body, nil
+}
+
+// FetchJWKSBody fetches a JWKS document, validates that it is syntactically a
+// JWKS and contains at least one key, and returns both the original bytes and
+// parsed keyset. The original bytes are important for OIDC, which ships the
+// IdP's JWKS material downstream verbatim; the parsed value is used by direct
+// JWKS consumers.
+func FetchJWKSBody(ctx context.Context, client *http.Client, requestURL, description string) ([]byte, jose.JSONWebKeySet, error) {
+	body, err := FetchBody(ctx, client, requestURL, description)
+	if err != nil {
+		return nil, jose.JSONWebKeySet{}, err
+	}
+	keyset, err := ValidateJWKSBody(body, requestURL, description)
+	if err != nil {
+		return nil, jose.JSONWebKeySet{}, err
+	}
+	return body, keyset, nil
+}
+
+func ValidateJWKSBody(body []byte, requestURL, description string) (jose.JSONWebKeySet, error) {
+	var keyset jose.JSONWebKeySet
+	if err := json.Unmarshal(body, &keyset); err != nil {
+		return jose.JSONWebKeySet{}, fmt.Errorf("%s response from %s is not a valid JWKS document: %w", description, requestURL, err)
+	}
+	if len(keyset.Keys) == 0 {
+		return jose.JSONWebKeySet{}, fmt.Errorf("%s response from %s contains no keys", description, requestURL)
+	}
+	return keyset, nil
 }

--- a/controller/pkg/agentgateway/remotehttp/client_test.go
+++ b/controller/pkg/agentgateway/remotehttp/client_test.go
@@ -1,0 +1,44 @@
+package remotehttp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateJWKSBodyAcceptsValidKeyset(t *testing.T) {
+	keyset, err := ValidateJWKSBody([]byte(`{"keys":[{"kty":"oct","k":"c2VjcmV0"}]}`), "https://idp.example/jwks", "JWKS")
+
+	require.NoError(t, err)
+	require.Len(t, keyset.Keys, 1)
+}
+
+func TestValidateJWKSBodyRejectsMalformedJSON(t *testing.T) {
+	_, err := ValidateJWKSBody([]byte(`not-json`), "https://idp.example/jwks", "OIDC JWKS")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "OIDC JWKS response from https://idp.example/jwks is not a valid JWKS document")
+}
+
+func TestValidateJWKSBodyRejectsEmptyKeyset(t *testing.T) {
+	_, err := ValidateJWKSBody([]byte(`{"keys":[]}`), "https://idp.example/jwks", "JWKS")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "JWKS response from https://idp.example/jwks contains no keys")
+}
+
+func TestValidateJWKSBodyRejectsNonJWKSJSON(t *testing.T) {
+	_, err := ValidateJWKSBody([]byte(`{"error":"temporarily_unavailable"}`), "https://idp.example/jwks", "JWKS")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "contains no keys")
+}
+
+func TestValidateJWKSBodyErrorIncludesSourceDescription(t *testing.T) {
+	_, err := ValidateJWKSBody([]byte(`{"keys":[]}`), "https://idp.example/oidc/jwks", "OIDC JWKS")
+
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "OIDC JWKS"))
+	require.True(t, strings.Contains(err.Error(), "https://idp.example/oidc/jwks"))
+}


### PR DESCRIPTION
Publish remote JWKS/OIDC fetch results through KRT collections and drive ConfigMap persistence from KRT events.

This removes the custom fanout path, shares request grouping, centralizes JWKS validation, and adds focused KRT-native tests.

Fork-local PR targeting `oidc-xds`; this does not create an upstream PR.