### PR TITLE
fix(remotecache): compile KRT fetched results

### DIFF
--- a/controller/pkg/agentgateway/remotecache/cache.go
+++ b/controller/pkg/agentgateway/remotecache/cache.go
@@ -35,7 +35,7 @@ type FetchedResults[R Result] struct {
 // NewFetchedResults constructs an empty, already-synced fetched-result collection.
 func NewFetchedResults[R Result](opts ...krt.CollectionOption) *FetchedResults[R] {
 	return &FetchedResults[R]{
-		collection: krt.NewStaticCollection(alwaysSynced{}, nil, opts...),
+		collection: krt.NewStaticCollection[FetchedRecord[R]](alwaysSynced{}, nil, opts...),
 	}
 }
 

--- a/controller/pkg/agentgateway/remotecache/collapse_test.go
+++ b/controller/pkg/agentgateway/remotecache/collapse_test.go
@@ -9,7 +9,6 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
-	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil"
 	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil/krttest"
 )
 


### PR DESCRIPTION
Fix the controller CI blockers surfaced after the KRT fetched-artifact refactor.

Changes:
- specify the `FetchedRecord[R]` type parameter when constructing the KRT static collection
- remove an unused import from the shared request collection tests

Fork-local PR targeting `oidc-xds`; this does not create an upstream PR.