### PR TITLE
chore: refresh audit fixes from oidc-xds

### DIFF
--- a/controller/pkg/agentgateway/remotecache/cache.go
+++ b/controller/pkg/agentgateway/remotecache/cache.go
@@ -35,7 +35,7 @@ type FetchedResults[R Result] struct {
 // NewFetchedResults constructs an empty, already-synced fetched-result collection.
 func NewFetchedResults[R Result](opts ...krt.CollectionOption) *FetchedResults[R] {
 	return &FetchedResults[R]{
-		collection: krt.NewStaticCollection(alwaysSynced{}, nil, opts...),
+		collection: krt.NewStaticCollection[FetchedRecord[R]](alwaysSynced{}, nil, opts...),
 	}
 }
 

--- a/controller/pkg/agentgateway/remotecache/collapse_test.go
+++ b/controller/pkg/agentgateway/remotecache/collapse_test.go
@@ -9,7 +9,6 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
-	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil"
 	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil/krttest"
 )
 


### PR DESCRIPTION
Fork-local maintenance PR to bring `oidc-xds-audit-fixes` up to date with the current `oidc-xds` head without modifying `oidc-xds`.

This keeps the audit branch current before any final squash/merge decision.